### PR TITLE
add gha workflow to publish to npm

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,0 +1,21 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the publishing of packages to npm. The workflow is triggered on release events and includes steps to set up the environment, install dependencies, and publish the package.

### Workflow automation:

* [`.github/workflows/publish-to-npm.yaml`](diffhunk://#diff-ba8d164be0b8439ec65972dd4bb482cd3f161af8113995eb0ca17131c73fc745R1-R21): Added a new workflow named "Publish Package to npmjs" that triggers on `release` events of type `published`. The workflow includes steps to check out the repository, configure the Node.js environment, install dependencies using `npm ci`, and publish the package to npm with provenance and public access. It uses the `NODE_AUTH_TOKEN` secret for authentication.