### PR TITLE
fix return type to only retun list for getChatsByUserId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/lexi",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A TypeScript library for real time messaging",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {
@@ -57,7 +57,7 @@
     "node": "^20.0.0 || >=22.0.0"
   },
   "dependencies": {
-    "@innobridge/qatar": "^0.0.2",
+    "@innobridge/qatar": "^0.0.1",
     "@innobridge/usermanagement": "^0.0.1",
     "@trpc/client": "^11.1.4",
     "@trpc/server": "^11.1.4",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "node": "^20.0.0 || >=22.0.0"
   },
   "dependencies": {
-    "@innobridge/qatar": "^0.0.1",
+    "@innobridge/qatar": "^0.0.2",
     "@innobridge/usermanagement": "^0.0.1",
     "@trpc/client": "^11.1.4",
     "@trpc/server": "^11.1.4",

--- a/src/api/chats.ts
+++ b/src/api/chats.ts
@@ -15,7 +15,7 @@ const getChatByChatId = async (chatId: string): Promise<Chat | null> => {
     return await getDatabaseClient()!.getChatByChatId(chatId);
 };
 
-const getChatsByUserId = async (chatId: string, updatedAfter?: number, limit?: number, offset?: number): Promise<Chat[] | null> => {
+const getChatsByUserId = async (chatId: string, updatedAfter?: number, limit?: number, offset?: number): Promise<Chat[]> => {
     if (!isDatabaseClientSet()) {
         throw new Error("Database client not initialized. Call initializeDatabase first.");
     }


### PR DESCRIPTION
This pull request includes updates to dependencies and a type adjustment in the `getChatsByUserId` function. The most important changes are outlined below.

### Dependency Updates:
* Updated the `@innobridge/qatar` dependency in `package.json` from version `^0.0.1` to `^0.0.2`, likely to incorporate bug fixes or new features.

### Type Adjustment:
* Modified the return type of the `getChatsByUserId` function in `src/api/chats.ts` to remove the possibility of returning `null`, ensuring it always returns an array of `Chat` objects. This change likely reflects a stronger guarantee about the function's behavior.