### PR TITLE
fix connectionId in chats to number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@innobridge/lexi",
-  "version": "0.0.0",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@innobridge/lexi",
-      "version": "0.0.0",
+      "version": "0.0.3",
       "license": "InnoBridge",
       "dependencies": {
-        "@innobridge/qatar": "^0.0.1",
-        "@innobridge/usermanagement": "^0.0.1",
+        "@innobridge/qatar": "^1.0.1",
+        "@innobridge/usermanagement": "^0.2.1",
         "@trpc/client": "^11.1.4",
         "@trpc/server": "^11.1.4",
         "pg": "^8.16.0",
@@ -56,13 +56,13 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.9.5.tgz",
-      "integrity": "sha512-KeIug5qV4LnzZD+16SLkJvdONPs2HQ7I1A7jbHYOGB37vQrQrus64Wu5XeNzbWFTN1Z5fAPSGuja8MfT2cBT4A==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.9.7.tgz",
+      "integrity": "sha512-D3iuzuDoadK6BKb7qFZEH332z4Sl5mxLuHMf8rKdIMHuOu1RQK0RqFJtKPcFvDxq0RvJ9MC+rK24P2Sa2tOoNA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@clerk/types": "^4.59.3",
+        "@clerk/types": "^4.60.1",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.5",
@@ -86,9 +86,9 @@
       }
     },
     "node_modules/@clerk/types": {
-      "version": "4.59.3",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.59.3.tgz",
-      "integrity": "sha512-xwOO/hfABzbFr3f1RaVXHsDDQ0+jYpm84GiaUDxo+mLsYUgD9f2GmGjKkgWybXzvsBsgZlycSwRXkeDD6utFqg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.60.1.tgz",
+      "integrity": "sha512-Lbt0/Q9W9BJtGz1IITdmeqal7y1zp9EaxOEMvsTEDhOxKf/0F/M1d0gJmHEU0puQzYPp9zJsIWC2yJjbgy3Y3Q==",
       "license": "MIT",
       "dependencies": {
         "csstype": "3.1.3"
@@ -523,9 +523,9 @@
       }
     },
     "node_modules/@innobridge/qatar": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@innobridge/qatar/-/qatar-0.0.1.tgz",
-      "integrity": "sha512-B1RFlSnGZJZKaMSVkEnzsF47tmNBhR/T5qvPHPDHf3jeb8a4/0TO9DWrjCJeQPgS2m604zbIZeXusJ/Wy1yWMg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@innobridge/qatar/-/qatar-1.0.1.tgz",
+      "integrity": "sha512-nhTHjaNielyZZ26LFpWoU6/l9+vHYIvMG97lLNkP41gZEODqlI54niw/7lHGsNcm0JDg70MVTIyQGvKwNS0ZPA==",
       "license": "InnoBridge",
       "dependencies": {
         "amqplib": "^0.10.8",
@@ -536,9 +536,9 @@
       }
     },
     "node_modules/@innobridge/usermanagement": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@innobridge/usermanagement/-/usermanagement-0.0.1.tgz",
-      "integrity": "sha512-VaNOoZnEMAcxLfw3O6PjXG1M1rIXf+WgEyv3eOxFXkruLpzfRQ4/QSNrJO1cMkax0Fat4KZvIvLqFH1CyxM/+g==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@innobridge/usermanagement/-/usermanagement-0.2.1.tgz",
+      "integrity": "sha512-OFLbnwNdPj2m7FSvRz2rNrLzegJmTnGKQ7qnhoJnStgW/SjoQQ5/a1dqeoy3o82wRQvqGuXU0NXCFDe9bIV+cQ==",
       "license": "InnoBridge",
       "dependencies": {
         "@clerk/backend": "^1.34.0",
@@ -1014,14 +1014,14 @@
       }
     },
     "node_modules/@types/pg": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.2.tgz",
-      "integrity": "sha512-+BKxo5mM6+/A1soSHBI7ufUglqYXntChLDyTbvcAn1Lawi9J7J9Ok3jt6w7I0+T/UDJ4CyhHk66+GZbwmkYxSg==",
+      "version": "8.15.4",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.4.tgz",
+      "integrity": "sha512-I6UNVBAoYbvuWkkU3oosC8yxqH21f4/Jc4DK71JLG3dT2mdlGe1z+ep/LQGXaKaOgcvUrsQoPRqfgtMcvZiJhg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
-        "pg-types": "^4.0.1"
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/qs": {
@@ -1886,12 +1886,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/obuf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-      "license": "MIT"
-    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -1992,15 +1986,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/pg-numeric": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
-      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/pg-pool": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.0.tgz",
@@ -2017,24 +2002,6 @@
       "license": "MIT"
     },
     "node_modules/pg-types": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
-      "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
-      "license": "MIT",
-      "dependencies": {
-        "pg-int8": "1.0.1",
-        "pg-numeric": "1.0.2",
-        "postgres-array": "~3.0.1",
-        "postgres-bytea": "~3.0.0",
-        "postgres-date": "~2.1.0",
-        "postgres-interval": "^3.0.0",
-        "postgres-range": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/pg/node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
@@ -2048,45 +2015,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/pg/node_modules/postgres-array": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pg/node_modules/postgres-bytea": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pg/node_modules/postgres-date": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
-      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pg/node_modules/postgres-interval": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
-      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/pgpass": {
@@ -2213,49 +2141,43 @@
       }
     },
     "node_modules/postgres-array": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
-      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=4"
       }
     },
     "node_modules/postgres-bytea": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
-      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
       "license": "MIT",
-      "dependencies": {
-        "obuf": "~1.1.2"
-      },
       "engines": {
-        "node": ">= 6"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/postgres-date": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
-      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/postgres-interval": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
-      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=0.10.0"
       }
-    },
-    "node_modules/postgres-range": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
-      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
-      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/lexi",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A TypeScript library for real time messaging",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {
@@ -57,8 +57,8 @@
     "node": "^20.0.0 || >=22.0.0"
   },
   "dependencies": {
-    "@innobridge/qatar": "^0.0.1",
-    "@innobridge/usermanagement": "^0.0.1",
+    "@innobridge/qatar": "^1.0.1",
+    "@innobridge/usermanagement": "^0.2.1",
     "@trpc/client": "^11.1.4",
     "@trpc/server": "^11.1.4",
     "pg": "^8.16.0",

--- a/src/models/chats.ts
+++ b/src/models/chats.ts
@@ -1,6 +1,6 @@
 interface Chat {
   chatId: string;
-  connectionId: string;
+  connectionId: number;
   userId1: string;
   userId2: string;
   createdAt: number;


### PR DESCRIPTION
This pull request includes updates to the `package.json` file to reflect version changes and dependency upgrades, as well as a modification to the `Chat` interface in `src/models/chats.ts` to change the type of `connectionId`.

### Updates to `package.json`:

* Updated the library version from `0.0.2` to `0.0.3` to reflect the new release.
* Upgraded dependencies:
  - `@innobridge/qatar` from `^0.0.1` to `^1.0.1`.
  - `@innobridge/usermanagement` from `^0.0.1` to `^0.2.1`.

### Changes to `Chat` interface:

* Changed the type of `connectionId` from `string` to `number` in the `Chat` interface in `src/models/chats.ts`. This likely reflects a requirement for numerical IDs instead of string-based ones.